### PR TITLE
feat: CLI argument parser

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -1,0 +1,281 @@
+/**
+ * CLI argument parser
+ *
+ * Provides command-line argument parsing for the abs CLI.
+ * Uses a lightweight custom parser - no external dependencies.
+ */
+
+/**
+ * CLI configuration from environment variables
+ */
+export interface CLIConfig {
+  server?: string;
+  token?: string;
+  device?: string;
+}
+
+/**
+ * CLI command arguments
+ */
+export interface CLIArgs {
+  library?: string;
+  query?: string;
+  id?: string;
+  device?: string;
+  name?: string;
+  minutes?: number;
+  [key: string]: string | number | undefined;
+}
+
+/**
+ * CLI flags
+ */
+export interface CLIFlags {
+  help?: boolean;
+  version?: boolean;
+  json?: boolean;
+  [key: string]: boolean | undefined;
+}
+
+/**
+ * CLI parsing result
+ */
+export interface CLIResult {
+  command: string;
+  subcommand?: string;
+  args: CLIArgs;
+  flags: CLIFlags;
+  config: CLIConfig;
+  exitCode: number;
+  error?: string;
+}
+
+/**
+ * Valid commands
+ */
+const COMMANDS = [
+  'library',
+  'books',
+  'search',
+  'play',
+  'resume',
+  'pause',
+  'stop',
+  'devices',
+  'device',
+  'sleep',
+  'help',
+  'version',
+];
+
+/**
+ * Parse CLI arguments
+ * @param argv - Command line arguments (without node and script name)
+ * @returns Parsed CLI result
+ */
+export function parseCLI(argv: string[]): CLIResult {
+  const result: CLIResult = {
+    command: 'help',
+    args: {},
+    flags: {},
+    config: {
+      server: process.env.ABS_SERVER,
+      token: process.env.ABS_TOKEN,
+      device: process.env.ABS_DEVICE,
+    },
+    exitCode: 0,
+  };
+
+  // Handle empty args
+  if (argv.length === 0) {
+    result.command = 'help';
+    return result;
+  }
+
+  // Parse flags and collect positional args
+  const positional: string[] = [];
+  let i = 0;
+
+  while (i < argv.length) {
+    const arg = argv[i];
+
+    // Global flags
+    if (arg === '--help' || arg === '-h') {
+      result.flags.help = true;
+      result.command = 'help';
+      return result;
+    }
+
+    if (arg === '--version' || arg === '-v') {
+      result.flags.version = true;
+      result.command = 'version';
+      return result;
+    }
+
+    if (arg === '--json') {
+      result.flags.json = true;
+      i++;
+      continue;
+    }
+
+    // Flag with value
+    if (arg === '--library' || arg === '-l') {
+      i++;
+      if (i < argv.length) {
+        result.args.library = argv[i];
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === '--device' || arg === '-d') {
+      i++;
+      if (i < argv.length) {
+        result.args.device = argv[i];
+      }
+      i++;
+      continue;
+    }
+
+    // Skip unknown flags
+    if (arg.startsWith('-')) {
+      i++;
+      continue;
+    }
+
+    // Positional argument
+    positional.push(arg);
+    i++;
+  }
+
+  // First positional is the command
+  if (positional.length === 0) {
+    result.command = 'help';
+    return result;
+  }
+
+  const command = positional[0];
+
+  // Validate command
+  if (!COMMANDS.includes(command)) {
+    result.error = `Unknown command: ${command}`;
+    result.exitCode = 2;
+    result.command = command;
+    return result;
+  }
+
+  result.command = command;
+
+  // Parse command-specific arguments
+  switch (command) {
+    case 'library':
+    case 'books':
+    case 'devices':
+    case 'pause':
+    case 'stop':
+    case 'resume':
+      // These commands have no required positional args
+      break;
+
+    case 'search':
+      if (positional.length < 2) {
+        result.error = 'search requires a query argument';
+        result.exitCode = 2;
+      } else {
+        result.args.query = positional.slice(1).join(' ');
+      }
+      break;
+
+    case 'play':
+      if (positional.length < 2) {
+        result.error = 'play requires a book id argument';
+        result.exitCode = 2;
+      } else {
+        result.args.id = positional[1];
+      }
+      break;
+
+    case 'device':
+      if (positional.length < 2) {
+        result.error = 'device requires a subcommand (set)';
+        result.exitCode = 2;
+      } else if (positional[1] === 'set') {
+        result.subcommand = 'set';
+        if (positional.length < 3) {
+          result.error = 'device set requires a device name';
+          result.exitCode = 2;
+        } else {
+          result.args.name = positional.slice(2).join(' ');
+        }
+      } else {
+        result.error = `Unknown device subcommand: ${positional[1]}`;
+        result.exitCode = 2;
+      }
+      break;
+
+    case 'sleep':
+      if (positional.length < 2) {
+        result.error = 'sleep requires a duration in minutes, "cancel", or "status"';
+        result.exitCode = 2;
+      } else if (positional[1] === 'cancel') {
+        result.subcommand = 'cancel';
+      } else if (positional[1] === 'status') {
+        result.subcommand = 'status';
+      } else {
+        const minutes = parseInt(positional[1], 10);
+        if (isNaN(minutes)) {
+          result.error = `Invalid sleep duration: ${positional[1]}`;
+          result.exitCode = 2;
+        } else {
+          result.args.minutes = minutes;
+        }
+      }
+      break;
+  }
+
+  return result;
+}
+
+/**
+ * Get help text for all commands
+ */
+export function getHelpText(): string {
+  return `Usage: abs <command> [options]
+
+Commands:
+  library                     List libraries
+  books [--library <id>]      List books
+  search "<query>"            Search library
+  play <id> [--device <name>] Start playback
+  resume [--device <name>]    Resume last book
+  pause                       Pause current playback
+  stop                        Stop and sync progress
+  devices                     List Cast devices
+  device set "<name>"         Set default device
+  sleep <minutes>             Set sleep timer
+  sleep cancel                Cancel sleep timer
+  sleep status                Show timer status
+
+Options:
+  -h, --help                  Show this help
+  -v, --version               Show version
+  --json                      Output as JSON
+
+Environment Variables:
+  ABS_SERVER                  Audiobookshelf server URL
+  ABS_TOKEN                   API token
+  ABS_DEVICE                  Default Cast device name
+
+Exit Codes:
+  0  Success
+  1  Error
+  2  Usage error
+`;
+}
+
+/**
+ * Get version string
+ */
+export function getVersion(): string {
+  return '0.1.0';
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for CLI argument parsing
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseCLI } from '../src/lib/cli.js';
+
+describe('CLI Parser', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('global flags', () => {
+    it('should parse --help flag', () => {
+      const result = parseCLI(['--help']);
+      expect(result.command).toBe('help');
+      expect(result.flags.help).toBe(true);
+    });
+
+    it('should parse -h flag', () => {
+      const result = parseCLI(['-h']);
+      expect(result.command).toBe('help');
+      expect(result.flags.help).toBe(true);
+    });
+
+    it('should parse --version flag', () => {
+      const result = parseCLI(['--version']);
+      expect(result.command).toBe('version');
+      expect(result.flags.version).toBe(true);
+    });
+
+    it('should parse -v flag', () => {
+      const result = parseCLI(['-v']);
+      expect(result.command).toBe('version');
+      expect(result.flags.version).toBe(true);
+    });
+
+    it('should parse --json flag', () => {
+      const result = parseCLI(['library', '--json']);
+      expect(result.flags.json).toBe(true);
+    });
+  });
+
+  describe('library command', () => {
+    it('should parse "library" command', () => {
+      const result = parseCLI(['library']);
+      expect(result.command).toBe('library');
+    });
+
+    it('should parse "library" with --json', () => {
+      const result = parseCLI(['library', '--json']);
+      expect(result.command).toBe('library');
+      expect(result.flags.json).toBe(true);
+    });
+  });
+
+  describe('books command', () => {
+    it('should parse "books" command', () => {
+      const result = parseCLI(['books']);
+      expect(result.command).toBe('books');
+    });
+
+    it('should parse "books --library <id>"', () => {
+      const result = parseCLI(['books', '--library', 'lib-123']);
+      expect(result.command).toBe('books');
+      expect(result.args.library).toBe('lib-123');
+    });
+
+    it('should parse "books -l <id>"', () => {
+      const result = parseCLI(['books', '-l', 'lib-123']);
+      expect(result.command).toBe('books');
+      expect(result.args.library).toBe('lib-123');
+    });
+  });
+
+  describe('search command', () => {
+    it('should parse "search <query>"', () => {
+      const result = parseCLI(['search', 'hobbit']);
+      expect(result.command).toBe('search');
+      expect(result.args.query).toBe('hobbit');
+    });
+
+    it('should parse "search" with quoted query', () => {
+      const result = parseCLI(['search', 'the lord of the rings']);
+      expect(result.command).toBe('search');
+      expect(result.args.query).toBe('the lord of the rings');
+    });
+
+    it('should error without query', () => {
+      const result = parseCLI(['search']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('play command', () => {
+    it('should parse "play <id>"', () => {
+      const result = parseCLI(['play', 'book-123']);
+      expect(result.command).toBe('play');
+      expect(result.args.id).toBe('book-123');
+    });
+
+    it('should parse "play <id> --device <name>"', () => {
+      const result = parseCLI(['play', 'book-123', '--device', 'Living Room']);
+      expect(result.command).toBe('play');
+      expect(result.args.id).toBe('book-123');
+      expect(result.args.device).toBe('Living Room');
+    });
+
+    it('should parse "play <id> -d <name>"', () => {
+      const result = parseCLI(['play', 'book-123', '-d', 'Kitchen']);
+      expect(result.command).toBe('play');
+      expect(result.args.id).toBe('book-123');
+      expect(result.args.device).toBe('Kitchen');
+    });
+
+    it('should error without id', () => {
+      const result = parseCLI(['play']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('resume command', () => {
+    it('should parse "resume"', () => {
+      const result = parseCLI(['resume']);
+      expect(result.command).toBe('resume');
+    });
+
+    it('should parse "resume --device <name>"', () => {
+      const result = parseCLI(['resume', '--device', 'Bedroom']);
+      expect(result.command).toBe('resume');
+      expect(result.args.device).toBe('Bedroom');
+    });
+  });
+
+  describe('pause command', () => {
+    it('should parse "pause"', () => {
+      const result = parseCLI(['pause']);
+      expect(result.command).toBe('pause');
+    });
+  });
+
+  describe('stop command', () => {
+    it('should parse "stop"', () => {
+      const result = parseCLI(['stop']);
+      expect(result.command).toBe('stop');
+    });
+  });
+
+  describe('devices command', () => {
+    it('should parse "devices"', () => {
+      const result = parseCLI(['devices']);
+      expect(result.command).toBe('devices');
+    });
+
+    it('should parse "devices --json"', () => {
+      const result = parseCLI(['devices', '--json']);
+      expect(result.command).toBe('devices');
+      expect(result.flags.json).toBe(true);
+    });
+  });
+
+  describe('device command', () => {
+    it('should parse "device set <name>"', () => {
+      const result = parseCLI(['device', 'set', 'Living Room']);
+      expect(result.command).toBe('device');
+      expect(result.subcommand).toBe('set');
+      expect(result.args.name).toBe('Living Room');
+    });
+
+    it('should error on "device set" without name', () => {
+      const result = parseCLI(['device', 'set']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('should error on "device" without subcommand', () => {
+      const result = parseCLI(['device']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('sleep command', () => {
+    it('should parse "sleep <minutes>"', () => {
+      const result = parseCLI(['sleep', '30']);
+      expect(result.command).toBe('sleep');
+      expect(result.args.minutes).toBe(30);
+    });
+
+    it('should parse "sleep cancel"', () => {
+      const result = parseCLI(['sleep', 'cancel']);
+      expect(result.command).toBe('sleep');
+      expect(result.subcommand).toBe('cancel');
+    });
+
+    it('should parse "sleep status"', () => {
+      const result = parseCLI(['sleep', 'status']);
+      expect(result.command).toBe('sleep');
+      expect(result.subcommand).toBe('status');
+    });
+
+    it('should error on invalid minutes', () => {
+      const result = parseCLI(['sleep', 'abc']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('should error on "sleep" without argument', () => {
+      const result = parseCLI(['sleep']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('unknown command', () => {
+    it('should error on unknown command', () => {
+      const result = parseCLI(['foobar']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('no command', () => {
+    it('should show help when no command', () => {
+      const result = parseCLI([]);
+      expect(result.command).toBe('help');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('should return exitCode 0 for valid commands', () => {
+      const result = parseCLI(['library']);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should return exitCode 2 for usage errors', () => {
+      const result = parseCLI(['play']);
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('environment variables', () => {
+    it('should use ABS_SERVER from env', () => {
+      process.env.ABS_SERVER = 'https://abs.example.com';
+      const result = parseCLI(['library']);
+      expect(result.config.server).toBe('https://abs.example.com');
+    });
+
+    it('should use ABS_TOKEN from env', () => {
+      process.env.ABS_TOKEN = 'secret-token';
+      const result = parseCLI(['library']);
+      expect(result.config.token).toBe('secret-token');
+    });
+
+    it('should use ABS_DEVICE from env', () => {
+      process.env.ABS_DEVICE = 'Living Room';
+      const result = parseCLI(['play', 'book-123']);
+      expect(result.config.device).toBe('Living Room');
+    });
+
+    it('should prefer flag over env for device', () => {
+      process.env.ABS_DEVICE = 'Living Room';
+      const result = parseCLI(['play', 'book-123', '--device', 'Kitchen']);
+      expect(result.args.device).toBe('Kitchen');
+    });
+  });
+});
+
+describe('CLI result structure', () => {
+  it('should have required properties', () => {
+    const result = parseCLI(['library']);
+    expect(result).toHaveProperty('command');
+    expect(result).toHaveProperty('args');
+    expect(result).toHaveProperty('flags');
+    expect(result).toHaveProperty('config');
+    expect(result).toHaveProperty('exitCode');
+  });
+});


### PR DESCRIPTION
## Summary
Implements CLI argument parsing as specified in Issue #5.

## Commands Supported
- `abs library` - list libraries
- `abs books [--library <id>]` - list books
- `abs search "<query>"` - search library
- `abs play <id> [--device <name>]` - start playback
- `abs resume [--device <name>]` - resume last book
- `abs pause` - pause current playback
- `abs stop` - stop and sync
- `abs devices` - list Cast devices
- `abs device set "<name>"` - set default device
- `abs sleep <minutes>` - set sleep timer
- `abs sleep cancel` - cancel timer
- `abs sleep status` - show timer status

## Global Options
- `--help, -h` - show usage
- `--version, -v` - show version
- `--json` - JSON output

## Environment Variables
- `ABS_SERVER` - Audiobookshelf server URL
- `ABS_TOKEN` - API token
- `ABS_DEVICE` - Default Cast device name

## Exit Codes
- 0 = success
- 2 = usage error

## Test Results
```
✓ tests/cli.test.ts (40 tests) 22ms
Test Files  4 passed (4)
Tests  76 passed (76)
```

## Checklist
- [x] Tests written and passing locally
- [x] Lint clean
- [x] Typecheck clean
- [x] TDD approach followed

Closes #5