### PR TITLE
[#18] Device discovery with mDNS

### DIFF
--- a/src/cast/discovery.ts
+++ b/src/cast/discovery.ts
@@ -1,0 +1,236 @@
+/**
+ * Cast device discovery via mDNS
+ *
+ * Discovers Google Cast devices on the local network using bonjour-service.
+ * Includes caching, fuzzy name matching, and ID lookup.
+ */
+
+import { Bonjour } from 'bonjour-service';
+import type { Service, Browser } from 'bonjour-service';
+import type { CastDevice, DiscoveryOptions } from './types.js';
+
+/**
+ * Extended discovery options including cache control
+ */
+interface ExtendedDiscoveryOptions extends DiscoveryOptions {
+  /** Force a fresh scan, ignoring cache */
+  forceRefresh?: boolean;
+}
+
+/**
+ * Options for DeviceDiscovery constructor
+ */
+interface DeviceDiscoveryOptions {
+  /** Cache TTL in milliseconds (default: 30000 = 30s) */
+  cacheTtlMs?: number;
+}
+
+/**
+ * Device discovery with caching and helper methods
+ */
+export class DeviceDiscovery {
+  private cache: CastDevice[] = [];
+  private cacheTime = 0;
+  private readonly cacheTtlMs: number;
+  private discoveryInProgress: Promise<CastDevice[]> | null = null;
+
+  constructor(options: DeviceDiscoveryOptions = {}) {
+    this.cacheTtlMs = options.cacheTtlMs ?? 30000;
+  }
+
+  /**
+   * Discover Cast devices on the network
+   *
+   * Results are cached to avoid repeated network scans.
+   * Use `forceRefresh: true` to bypass the cache.
+   *
+   * @param options - Discovery options
+   * @returns Array of discovered Cast devices
+   */
+  async discoverDevices(options: ExtendedDiscoveryOptions = {}): Promise<CastDevice[]> {
+    const timeout = options.timeout ?? 5000;
+    const forceRefresh = options.forceRefresh ?? false;
+
+    // Check cache validity
+    if (!forceRefresh && this.isCacheValid()) {
+      return this.cache;
+    }
+
+    // If discovery is already in progress, wait for it
+    if (this.discoveryInProgress) {
+      return this.discoveryInProgress;
+    }
+
+    // Start new discovery
+    this.discoveryInProgress = this.performDiscovery(timeout);
+
+    try {
+      const devices = await this.discoveryInProgress;
+      this.cache = devices;
+      this.cacheTime = Date.now();
+      return devices;
+    } finally {
+      this.discoveryInProgress = null;
+    }
+  }
+
+  /**
+   * Find a device by its friendly name
+   *
+   * Performs case-insensitive partial matching.
+   *
+   * @param name - Device name or partial name to search for
+   * @returns The matching device, or null if not found
+   */
+  async findDeviceByName(name: string): Promise<CastDevice | null> {
+    const devices = await this.discoverDevices();
+    const normalizedSearch = name.toLowerCase();
+
+    // Try exact match first
+    const exactMatch = devices.find(
+      (d) => d.name.toLowerCase() === normalizedSearch
+    );
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    // Try partial match
+    const partialMatch = devices.find((d) =>
+      d.name.toLowerCase().includes(normalizedSearch)
+    );
+    return partialMatch ?? null;
+  }
+
+  /**
+   * Find a device by its Cast ID
+   *
+   * @param id - The Cast device ID from mDNS TXT record
+   * @returns The matching device, or null if not found
+   */
+  async findDeviceById(id: string): Promise<CastDevice | null> {
+    const devices = await this.discoverDevices();
+    return devices.find((d) => d.id === id) ?? null;
+  }
+
+  /**
+   * Clear the cached device list
+   */
+  clearCache(): void {
+    this.cache = [];
+    this.cacheTime = 0;
+  }
+
+  /**
+   * Get cached devices without triggering a scan
+   */
+  getCachedDevices(): CastDevice[] {
+    return [...this.cache];
+  }
+
+  /**
+   * Check if the cache is still valid
+   *
+   * An empty device list is considered valid if it was populated recently.
+   */
+  private isCacheValid(): boolean {
+    // If we've never scanned, cache is invalid
+    if (this.cacheTime === 0) {
+      return false;
+    }
+    return Date.now() - this.cacheTime < this.cacheTtlMs;
+  }
+
+  /**
+   * Perform the actual mDNS discovery
+   */
+  private performDiscovery(timeout: number): Promise<CastDevice[]> {
+    return new Promise((resolve) => {
+      const devices: CastDevice[] = [];
+      const bonjour = new Bonjour();
+
+      const browser: Browser = bonjour.find({ type: 'googlecast' });
+
+      browser.on('up', (service: Service) => {
+        const device = this.serviceToDevice(service);
+
+        // Avoid duplicates by host and port
+        if (!devices.some((d) => d.host === device.host && d.port === device.port)) {
+          devices.push(device);
+        }
+      });
+
+      // Resolve after timeout
+      setTimeout(() => {
+        browser.stop();
+        bonjour.destroy();
+        resolve(devices);
+      }, timeout);
+    });
+  }
+
+  /**
+   * Convert a Bonjour service to a CastDevice
+   */
+  private serviceToDevice(service: Service): CastDevice {
+    const txtRecord = service.txt as Record<string, string> | undefined;
+
+    return {
+      name: service.name,
+      host: service.addresses?.[0] ?? service.host,
+      port: service.port || 8009,
+      id: txtRecord?.id,
+    };
+  }
+}
+
+// Shared instance for standalone functions
+let sharedDiscovery: DeviceDiscovery | null = null;
+
+/**
+ * Get or create the shared discovery instance
+ */
+function getSharedDiscovery(): DeviceDiscovery {
+  sharedDiscovery ??= new DeviceDiscovery();
+  return sharedDiscovery;
+}
+
+/**
+ * Discover Cast devices on the network (standalone function)
+ *
+ * Uses a shared discovery instance with caching.
+ *
+ * @param options - Discovery options
+ * @returns Array of discovered Cast devices
+ */
+export async function discoverDevices(
+  options: ExtendedDiscoveryOptions = {}
+): Promise<CastDevice[]> {
+  return getSharedDiscovery().discoverDevices(options);
+}
+
+/**
+ * Find a device by name (standalone function)
+ *
+ * @param name - Device name or partial name
+ * @returns The matching device, or null if not found
+ */
+export async function findDeviceByName(name: string): Promise<CastDevice | null> {
+  return getSharedDiscovery().findDeviceByName(name);
+}
+
+/**
+ * Find a device by Cast ID (standalone function)
+ *
+ * @param id - The Cast device ID
+ * @returns The matching device, or null if not found
+ */
+export async function findDeviceById(id: string): Promise<CastDevice | null> {
+  return getSharedDiscovery().findDeviceById(id);
+}
+
+/**
+ * Clear the shared discovery cache (standalone function)
+ */
+export function clearDiscoveryCache(): void {
+  getSharedDiscovery().clearCache();
+}

--- a/src/cast/index.ts
+++ b/src/cast/index.ts
@@ -8,6 +8,15 @@
 // Re-export all types
 export * from './types.js';
 
+// Re-export discovery module
+export {
+  DeviceDiscovery,
+  discoverDevices,
+  findDeviceByName,
+  findDeviceById,
+  clearDiscoveryCache,
+} from './discovery.js';
+
 // Re-export castv2-client types for convenience
 export { Client, DefaultMediaReceiver } from 'castv2-client';
 export { Bonjour } from 'bonjour-service';

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Tests for Cast device discovery
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Create mock classes
+class MockBrowser extends EventEmitter {
+  stop = vi.fn();
+}
+
+class MockBonjour {
+  browser: MockBrowser;
+  destroyed = false;
+
+  constructor() {
+    this.browser = new MockBrowser();
+  }
+
+  find = vi.fn(() => {
+    return this.browser;
+  });
+
+  destroy = vi.fn(() => {
+    this.destroyed = true;
+  });
+}
+
+// Store mock instance for test access
+let mockBonjourInstance: MockBonjour | null = null;
+
+// Mock bonjour-service before importing discovery
+vi.mock('bonjour-service', () => {
+  return {
+    Bonjour: vi.fn(() => {
+      mockBonjourInstance = new MockBonjour();
+      return mockBonjourInstance;
+    }),
+  };
+});
+
+import {
+  DeviceDiscovery,
+  discoverDevices,
+  findDeviceByName,
+  findDeviceById,
+  clearDiscoveryCache,
+} from '../src/cast/discovery.js';
+
+describe('DeviceDiscovery', () => {
+  let discovery: DeviceDiscovery;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    discovery = new DeviceDiscovery();
+    mockBonjourInstance = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    clearDiscoveryCache();
+  });
+
+  describe('discoverDevices', () => {
+    it('should discover Cast devices on the network', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 5000 });
+
+      // Wait for Bonjour to be instantiated
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Simulate device discovery
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        host: 'living-room.local',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1', md: 'Google Home' },
+      });
+
+      // Fast-forward past timeout
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const devices = await discoverPromise;
+      expect(devices).toHaveLength(1);
+      expect(devices[0].name).toBe('Living Room Speaker');
+      expect(devices[0].host).toBe('192.168.1.100');
+      expect(devices[0].port).toBe(8009);
+      expect(devices[0].id).toBe('device-1');
+    });
+
+    it('should use default timeout if not specified', async () => {
+      const discoverPromise = discovery.discoverDevices();
+
+      // Should resolve after 5000ms (default)
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const devices = await discoverPromise;
+      expect(devices).toEqual([]);
+    });
+
+    it('should return empty array on timeout with no devices', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const devices = await discoverPromise;
+      expect(devices).toEqual([]);
+    });
+
+    it('should deduplicate devices by host and port', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 5000 });
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Emit same device twice
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const devices = await discoverPromise;
+      expect(devices).toHaveLength(1);
+    });
+
+    it('should handle devices without addresses array', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 5000 });
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Kitchen Display',
+        host: 'kitchen.local',
+        port: 8009,
+        txt: { id: 'device-2' },
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const devices = await discoverPromise;
+      expect(devices).toHaveLength(1);
+      expect(devices[0].host).toBe('kitchen.local');
+    });
+
+    it('should stop browser and destroy bonjour after timeout', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      expect(mockBonjourInstance?.browser.stop).toHaveBeenCalled();
+      expect(mockBonjourInstance?.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe('caching', () => {
+    it('should cache discovery results', async () => {
+      // First discovery
+      const promise1 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      const devices1 = await promise1;
+
+      // Record the bonjour instance
+      const firstBonjour = mockBonjourInstance;
+
+      // Second discovery should return cached results (no new Bonjour instance)
+      const devices2 = await discovery.discoverDevices({ timeout: 1000 });
+
+      expect(devices2).toEqual(devices1);
+      expect(mockBonjourInstance).toBe(firstBonjour); // Same instance means no new scan
+    });
+
+    it('should respect cache TTL', async () => {
+      // Discovery with 2s TTL
+      discovery = new DeviceDiscovery({ cacheTtlMs: 2000 });
+
+      // First discovery
+      const promise1 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Device 1',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      const devices1 = await promise1;
+      expect(devices1).toHaveLength(1);
+
+      // Advance past cache TTL
+      await vi.advanceTimersByTimeAsync(2500);
+
+      // Second discovery should re-scan (new Bonjour instance)
+      const promise2 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Device 2',
+        addresses: ['192.168.1.101'],
+        port: 8009,
+        txt: { id: 'device-2' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      const devices2 = await promise2;
+
+      // Should have new device from fresh scan
+      expect(devices2.some((d) => d.id === 'device-2')).toBe(true);
+    });
+
+    it('should allow forcing a fresh scan', async () => {
+      // First discovery
+      const promise1 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Device 1',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise1;
+
+      const firstBonjour = mockBonjourInstance;
+
+      // Force fresh scan
+      const promise2 = discovery.discoverDevices({ timeout: 1000, forceRefresh: true });
+      await vi.advanceTimersByTimeAsync(10);
+      // New instance created
+      expect(mockBonjourInstance).not.toBe(firstBonjour);
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise2;
+    });
+  });
+
+  describe('findDeviceByName', () => {
+    it('should find device by exact name', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      const device = await discovery.findDeviceByName('Living Room Speaker');
+      expect(device).not.toBeNull();
+      expect(device?.name).toBe('Living Room Speaker');
+    });
+
+    it('should find device by partial name (case-insensitive)', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      const device = await discovery.findDeviceByName('living room');
+      expect(device).not.toBeNull();
+      expect(device?.name).toBe('Living Room Speaker');
+    });
+
+    it('should return null if device not found', async () => {
+      // Discovery with no devices
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      // findDeviceByName will use cached (empty) results
+      const device = await discovery.findDeviceByName('Nonexistent Device');
+      expect(device).toBeNull();
+    });
+  });
+
+  describe('findDeviceById', () => {
+    it('should find device by Cast ID', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Living Room Speaker',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'abc123' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      const device = await discovery.findDeviceById('abc123');
+      expect(device).not.toBeNull();
+      expect(device?.id).toBe('abc123');
+    });
+
+    it('should return null if ID not found', async () => {
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      const device = await discovery.findDeviceById('nonexistent');
+      expect(device).toBeNull();
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear cached devices', async () => {
+      // First discovery
+      const promise1 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Device 1',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise1;
+
+      const firstBonjour = mockBonjourInstance;
+
+      // Clear cache
+      discovery.clearCache();
+
+      // Next discovery should re-scan
+      const promise2 = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      // Should have new Bonjour instance
+      expect(mockBonjourInstance).not.toBe(firstBonjour);
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise2;
+    });
+  });
+
+  describe('getCachedDevices', () => {
+    it('should return cached devices without triggering scan', async () => {
+      // Before any discovery
+      expect(discovery.getCachedDevices()).toEqual([]);
+
+      // After discovery
+      const discoverPromise = discovery.discoverDevices({ timeout: 1000 });
+      await vi.advanceTimersByTimeAsync(10);
+      mockBonjourInstance?.browser.emit('up', {
+        name: 'Device 1',
+        addresses: ['192.168.1.100'],
+        port: 8009,
+        txt: { id: 'device-1' },
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await discoverPromise;
+
+      const cached = discovery.getCachedDevices();
+      expect(cached).toHaveLength(1);
+      expect(cached[0].name).toBe('Device 1');
+    });
+  });
+});
+
+describe('Standalone functions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearDiscoveryCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    clearDiscoveryCache();
+  });
+
+  it('discoverDevices should use shared discovery instance', async () => {
+    const promise = discoverDevices({ timeout: 1000 });
+    await vi.advanceTimersByTimeAsync(1000);
+    const devices = await promise;
+    expect(Array.isArray(devices)).toBe(true);
+  });
+
+  it('findDeviceByName should discover and find', async () => {
+    // Start discovery
+    const discoverPromise = discoverDevices({ timeout: 1000 });
+    await vi.advanceTimersByTimeAsync(10);
+    mockBonjourInstance?.browser.emit('up', {
+      name: 'Test Speaker',
+      addresses: ['192.168.1.100'],
+      port: 8009,
+      txt: { id: 'test-1' },
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    await discoverPromise;
+
+    // Now findByName should use cache
+    const device = await findDeviceByName('Test Speaker');
+    expect(device?.name).toBe('Test Speaker');
+  });
+
+  it('findDeviceById should return null for unknown ID', async () => {
+    const promise = discoverDevices({ timeout: 1000 });
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    const device = await findDeviceById('nonexistent');
+    expect(device).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements mDNS-based device discovery for finding Google Cast devices on the local network.

## Changes

### New: `src/cast/discovery.ts`

- `DeviceDiscovery` class with caching support
- `discoverDevices(options)` - discovers Cast devices via mDNS with configurable timeout
- `findDeviceByName(name)` - finds device by name with case-insensitive fuzzy matching
- `findDeviceById(id)` - finds device by exact Cast ID
- `clearCache()` - manually clear the device cache
- `getCachedDevices()` - get cached devices without triggering scan

### Features

- **Caching**: Results cached with configurable TTL (default 30s) to avoid repeated scans
- **Fuzzy matching**: Find devices by partial name, case-insensitive
- **Deduplication**: Devices deduplicated by host:port
- **Graceful timeout**: Returns empty list on timeout, doesn't throw
- **Singleton pattern**: Standalone functions use a shared instance

## Acceptance Criteria

- [x] Can discover Cast devices on local network
- [x] Results are cached to avoid repeated scans
- [x] Can find device by friendly name (fuzzy match)
- [x] Can find device by Cast ID
- [x] Handles timeout gracefully (returns empty list, not error)
- [x] Unit tests pass

## Testing

```
pnpm test:run     # 176 tests pass
pnpm typecheck    # No errors
pnpm lint         # Clean
```

Closes #18