### PR TITLE
[#21] Volume control and smooth fade

### DIFF
--- a/src/proxy/fade.ts
+++ b/src/proxy/fade.ts
@@ -1,0 +1,174 @@
+/**
+ * Volume Fade Utilities
+ *
+ * Provides smooth volume fading for the audio proxy.
+ * Uses PCM volume control for silent fades (no Cast "bloop" sounds).
+ */
+
+import type { VolumeTransform } from './volume-transform.js';
+
+/**
+ * Options for fadeVolume
+ */
+export interface FadeOptions {
+  /** Number of steps for the fade (default: 30) */
+  steps?: number;
+  /** AbortSignal for cancellation */
+  signal?: AbortSignal;
+  /** Callback for each step (for progress reporting) */
+  onStep?: (currentVolume: number, step: number, totalSteps: number) => void;
+}
+
+/**
+ * Result of a fade operation
+ */
+export interface FadeResult {
+  /** Whether the fade completed fully */
+  completed: boolean;
+  /** Final volume level */
+  finalVolume: number;
+  /** Number of steps executed */
+  stepsExecuted: number;
+  /** Whether the fade was cancelled */
+  cancelled: boolean;
+}
+
+/**
+ * Error thrown when fade is aborted
+ */
+export class FadeAbortedError extends Error {
+  constructor(
+    public readonly finalVolume: number,
+    public readonly stepsExecuted: number
+  ) {
+    super('Fade operation was aborted');
+    this.name = 'FadeAbortedError';
+  }
+}
+
+/**
+ * Smoothly fade volume from one level to another
+ *
+ * Uses the VolumeTransform's PCM volume control for completely silent fades.
+ * Latency: ~2-4 seconds from setVolume() to audible change.
+ *
+ * @param transform - The VolumeTransform to control
+ * @param from - Starting volume (0.0 - 1.5)
+ * @param to - Target volume (0.0 - 1.5)
+ * @param durationMs - Total fade duration in milliseconds
+ * @param options - Additional options
+ * @returns Promise that resolves when fade completes
+ */
+export async function fadeVolume(
+  transform: VolumeTransform,
+  from: number,
+  to: number,
+  durationMs: number,
+  options: FadeOptions = {}
+): Promise<FadeResult> {
+  const steps = options.steps ?? 30;
+  const signal = options.signal;
+  const onStep = options.onStep;
+
+  const stepDuration = durationMs / steps;
+  const volumeDelta = (from - to) / steps;
+
+  let currentVolume = from;
+  let stepsExecuted = 0;
+
+  // Set initial volume
+  transform.setVolume(from);
+
+  for (let i = 1; i <= steps; i++) {
+    // Check for cancellation
+    if (signal?.aborted) {
+      return {
+        completed: false,
+        finalVolume: currentVolume,
+        stepsExecuted,
+        cancelled: true,
+      };
+    }
+
+    // Calculate and apply new volume
+    currentVolume = Math.max(0, Math.min(1.5, from - volumeDelta * i));
+    transform.setVolume(currentVolume);
+    stepsExecuted = i;
+
+    // Report progress
+    onStep?.(currentVolume, i, steps);
+
+    // Wait for next step (except on last step)
+    if (i < steps) {
+      await sleep(stepDuration, signal);
+
+      // Check again after sleep
+      if (signal?.aborted) {
+        return {
+          completed: false,
+          finalVolume: currentVolume,
+          stepsExecuted,
+          cancelled: true,
+        };
+      }
+    }
+  }
+
+  // Ensure we end exactly at target
+  transform.setVolume(to);
+
+  return {
+    completed: true,
+    finalVolume: to,
+    stepsExecuted: steps,
+    cancelled: false,
+  };
+}
+
+/**
+ * Fade out (volume to 0) over duration
+ */
+export async function fadeOut(
+  transform: VolumeTransform,
+  durationMs: number,
+  options: FadeOptions = {}
+): Promise<FadeResult> {
+  const currentVolume = transform.volume;
+  return fadeVolume(transform, currentVolume, 0, durationMs, options);
+}
+
+/**
+ * Fade in (0 to volume) over duration
+ */
+export async function fadeIn(
+  transform: VolumeTransform,
+  targetVolume: number,
+  durationMs: number,
+  options: FadeOptions = {}
+): Promise<FadeResult> {
+  return fadeVolume(transform, 0, targetVolume, durationMs, options);
+}
+
+/**
+ * Sleep utility that respects AbortSignal
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = (): void => {
+      clearTimeout(timeout);
+      resolve();
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -17,3 +17,12 @@ export {
   type ProxyServerOptions,
   type StreamSession,
 } from './server.js';
+
+export {
+  fadeVolume,
+  fadeOut,
+  fadeIn,
+  FadeAbortedError,
+  type FadeOptions,
+  type FadeResult,
+} from './fade.js';

--- a/tests/fade.test.ts
+++ b/tests/fade.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for volume fade utilities
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fadeVolume, fadeOut, fadeIn } from '../src/proxy/fade.js';
+import { VolumeTransform } from '../src/proxy/volume-transform.js';
+
+describe('Volume Fade', () => {
+  let transform: VolumeTransform;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    transform = new VolumeTransform();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('fadeVolume', () => {
+    it('should fade from one volume to another', async () => {
+      const fadePromise = fadeVolume(transform, 1.0, 0.0, 1000, { steps: 10 });
+
+      // Advance through all steps
+      for (let i = 0; i < 10; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      const result = await fadePromise;
+
+      expect(result.completed).toBe(true);
+      expect(result.finalVolume).toBe(0);
+      expect(result.stepsExecuted).toBe(10);
+      expect(result.cancelled).toBe(false);
+    });
+
+    it('should set intermediate volume levels', async () => {
+      const volumes: number[] = [];
+      const onStep = (vol: number): void => {
+        volumes.push(vol);
+      };
+
+      const fadePromise = fadeVolume(transform, 1.0, 0.0, 500, {
+        steps: 5,
+        onStep,
+      });
+
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      await fadePromise;
+
+      expect(volumes).toHaveLength(5);
+      expect(volumes[0]).toBeCloseTo(0.8, 1);
+      expect(volumes[4]).toBeCloseTo(0, 1);
+    });
+
+    it('should support cancellation via AbortSignal', async () => {
+      const controller = new AbortController();
+
+      const fadePromise = fadeVolume(transform, 1.0, 0.0, 1000, {
+        steps: 10,
+        signal: controller.signal,
+      });
+
+      // Advance 3 steps
+      await vi.advanceTimersByTimeAsync(300);
+
+      // Abort
+      controller.abort();
+
+      // Continue time
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const result = await fadePromise;
+
+      expect(result.completed).toBe(false);
+      expect(result.cancelled).toBe(true);
+      expect(result.stepsExecuted).toBeLessThan(10);
+    });
+
+    it('should fade up (volume increase)', async () => {
+      transform.setVolume(0.2);
+
+      const fadePromise = fadeVolume(transform, 0.2, 1.0, 500, { steps: 4 });
+
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(125);
+      }
+
+      const result = await fadePromise;
+
+      expect(result.completed).toBe(true);
+      expect(result.finalVolume).toBe(1.0);
+    });
+
+    it('should clamp volume to valid range', async () => {
+      const fadePromise = fadeVolume(transform, 2.0, -0.5, 100, { steps: 2 });
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      await fadePromise;
+
+      // Start clamped to 1.5, end clamped to 0
+      expect(transform.volume).toBe(0);
+    });
+  });
+
+  describe('fadeOut', () => {
+    it('should fade from current volume to 0', async () => {
+      transform.setVolume(0.8);
+
+      const fadePromise = fadeOut(transform, 500, { steps: 5 });
+
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      const result = await fadePromise;
+
+      expect(result.completed).toBe(true);
+      expect(result.finalVolume).toBe(0);
+    });
+  });
+
+  describe('fadeIn', () => {
+    it('should fade from 0 to target volume', async () => {
+      transform.setVolume(0);
+
+      const fadePromise = fadeIn(transform, 1.0, 500, { steps: 5 });
+
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      const result = await fadePromise;
+
+      expect(result.completed).toBe(true);
+      expect(result.finalVolume).toBe(1.0);
+    });
+  });
+
+  describe('step callback', () => {
+    it('should call onStep for each step', async () => {
+      const onStep = vi.fn();
+
+      const fadePromise = fadeVolume(transform, 1.0, 0.0, 300, {
+        steps: 3,
+        onStep,
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      await fadePromise;
+
+      expect(onStep).toHaveBeenCalledTimes(3);
+      expect(onStep).toHaveBeenNthCalledWith(1, expect.any(Number), 1, 3);
+      expect(onStep).toHaveBeenNthCalledWith(2, expect.any(Number), 2, 3);
+      expect(onStep).toHaveBeenNthCalledWith(3, expect.any(Number), 3, 3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements smooth volume fade utilities for the audio proxy.

## Changes

### New: `src/proxy/fade.ts`

- `fadeVolume(transform, from, to, durationMs, options)` - Smooth volume transition
- `fadeOut(transform, durationMs, options)` - Convenience for fading to 0
- `fadeIn(transform, targetVolume, durationMs, options)` - Convenience for fading from 0

### Features

- **Silent fades**: Uses PCM volume control (no Cast bloops)
- **Cancellation**: AbortSignal support for stopping mid-fade
- **Progress**: onStep callback for progress reporting
- **Configurable steps**: Control granularity of the fade

### Usage

```typescript
// Fade out over 30 seconds
await fadeOut(pipeline.getVolumeTransform(), 30000);

// Fade with cancellation support
const controller = new AbortController();
const result = await fadeVolume(transform, 1.0, 0.0, 30000, {
  signal: controller.signal,
  onStep: (vol, step, total) => console.log(`Step ${step}/${total}: ${vol}`)
});
```

## Acceptance Criteria

- [x] Can set volume level (0.0 to 1.5)
- [x] Can fade volume smoothly over specified duration
- [x] Fade can be cancelled mid-operation
- [x] Unit tests pass

## Testing

```
pnpm test:run     # 229 tests pass
pnpm typecheck    # No errors
pnpm lint         # Clean
```

Closes #21