### PR TITLE
[#22] Sleep timer with fade-out

### DIFF
--- a/src/cast/index.ts
+++ b/src/cast/index.ts
@@ -29,6 +29,14 @@ export {
   type PositionTrackerOptions,
 } from './position-tracker.js';
 
+// Re-export sleep timer
+export {
+  CastSleepTimer,
+  type CastSleepTimerOptions,
+  type CastSleepTimerState,
+  type SleepTimerPhase,
+} from './sleep-timer.js';
+
 // Re-export castv2-client types for convenience
 export { Client, DefaultMediaReceiver } from 'castv2-client';
 export { Bonjour } from 'bonjour-service';

--- a/src/cast/sleep-timer.ts
+++ b/src/cast/sleep-timer.ts
@@ -1,0 +1,379 @@
+/**
+ * Cast Sleep Timer with Fade-out
+ *
+ * Skill-managed sleep timer with countdown, silent volume fade-out via audio proxy,
+ * and position preservation. The Cast device volume is never touched — fade happens
+ * in the PCM stream via the VolumeTransform.
+ *
+ * Architecture:
+ * Timer countdown → Poll position → Fade volume (via proxy) → Pause Cast → Sync final position
+ */
+
+import type { CastClient } from './client.js';
+import type { VolumeTransform } from '../proxy/volume-transform.js';
+import { fadeOut, type FadeResult } from '../proxy/fade.js';
+import { PlayerState } from './types.js';
+
+/**
+ * Phase of the sleep timer lifecycle
+ */
+export type SleepTimerPhase = 'inactive' | 'countdown' | 'fading' | 'completing';
+
+/**
+ * Options for CastSleepTimer
+ */
+export interface CastSleepTimerOptions {
+  /** Time until fade starts (milliseconds) */
+  durationMs: number;
+  /** Fade duration in milliseconds (default: 30000 = 30s) */
+  fadeDurationMs?: number;
+  /** Number of fade steps (default: 30) */
+  fadeSteps?: number;
+  /** Position sync interval in milliseconds (default: 10000 = 10s) */
+  syncIntervalMs?: number;
+  /** Latency compensation in milliseconds (default: 2000 = 2s) */
+  latencyCompensationMs?: number;
+  /** Progress callback - receives remaining milliseconds */
+  onProgress?: (remainingMs: number) => void;
+  /** Position sync callback - called periodically with current position */
+  onPositionSync?: (position: number) => Promise<void> | void;
+  /** Completion callback - called with final position after fade and pause */
+  onComplete?: (finalPosition: number) => void;
+  /** Error callback - called if timer encounters an error */
+  onError?: (error: Error, position: number) => void;
+}
+
+/**
+ * Current state of the sleep timer
+ */
+export interface CastSleepTimerState {
+  /** Whether the timer is active */
+  active: boolean;
+  /** Current phase */
+  phase: SleepTimerPhase;
+  /** Remaining time until fade starts (milliseconds) */
+  remainingMs: number;
+  /** Current playback position (seconds) */
+  position: number;
+  /** Total duration setting (milliseconds) */
+  totalDurationMs: number;
+  /** Fade duration setting (milliseconds) */
+  fadeDurationMs: number;
+}
+
+/**
+ * Sleep timer that integrates with audio proxy for silent volume fades.
+ *
+ * Uses the VolumeTransform's PCM volume control for completely silent fades -
+ * no Cast "bloop" sounds. Position is tracked during countdown and synced
+ * to Audiobookshelf before completion.
+ */
+export class CastSleepTimer {
+  private readonly fadeDurationMs: number;
+  private readonly fadeSteps: number;
+  private readonly syncIntervalMs: number;
+  private readonly latencyCompensationMs: number;
+  private readonly onProgress?: (remainingMs: number) => void;
+  private readonly onPositionSync?: (position: number) => Promise<void> | void;
+  private readonly onComplete?: (finalPosition: number) => void;
+  private readonly onError?: (error: Error, position: number) => void;
+
+  private phase: SleepTimerPhase = 'inactive';
+  private startTime = 0;
+  private endTime = 0;
+  private lastPosition = 0;
+  private countdownInterval?: ReturnType<typeof setInterval>;
+  private syncInterval?: ReturnType<typeof setInterval>;
+  private countdownTimeout?: ReturnType<typeof setTimeout>;
+  private abortController?: AbortController;
+  private runPromiseResolve?: () => void;
+
+  /**
+   * Create a new CastSleepTimer
+   *
+   * @param castClient - The Cast client for pause/status
+   * @param volumeTransform - The VolumeTransform for fade control
+   * @param options - Timer options
+   */
+  constructor(
+    private readonly castClient: CastClient,
+    private readonly volumeTransform: VolumeTransform,
+    private readonly options: CastSleepTimerOptions
+  ) {
+    this.fadeDurationMs = options.fadeDurationMs ?? 30000;
+    this.fadeSteps = options.fadeSteps ?? 30;
+    this.syncIntervalMs = options.syncIntervalMs ?? 10000;
+    this.latencyCompensationMs = options.latencyCompensationMs ?? 2000;
+    this.onProgress = options.onProgress;
+    this.onPositionSync = options.onPositionSync;
+    this.onComplete = options.onComplete;
+    this.onError = options.onError;
+  }
+
+  /**
+   * Start the sleep timer
+   *
+   * @throws Error if already running
+   * @returns Promise that resolves when timer completes or is cancelled
+   */
+  async start(): Promise<void> {
+    if (this.phase !== 'inactive') {
+      throw new Error('Sleep timer is already running');
+    }
+
+    this.phase = 'countdown';
+    this.startTime = Date.now();
+    // Account for latency: start fade slightly early
+    this.endTime = this.startTime + this.options.durationMs - this.latencyCompensationMs;
+    this.abortController = new AbortController();
+
+    // Start position polling
+    await this.pollPosition();
+    this.syncInterval = setInterval(() => {
+      void this.pollPosition();
+    }, this.syncIntervalMs);
+
+    // Start progress reporting
+    this.countdownInterval = setInterval(() => {
+      this.reportProgress();
+    }, 1000);
+
+    // Schedule fade
+    const timeUntilFade = Math.max(0, this.endTime - Date.now());
+    this.countdownTimeout = setTimeout(() => {
+      void this.executeStop();
+    }, timeUntilFade);
+
+    // Return a promise that resolves when complete or cancelled
+    return new Promise((resolve) => {
+      this.runPromiseResolve = resolve;
+    });
+  }
+
+  /**
+   * Cancel the sleep timer
+   *
+   * @returns Last known playback position (seconds)
+   */
+  cancel(): number {
+    const position = this.lastPosition;
+
+    // Abort any in-progress fade
+    this.abortController?.abort();
+
+    this.cleanup();
+    return position;
+  }
+
+  /**
+   * Get current tracked playback position
+   *
+   * @returns Position in seconds
+   */
+  getPosition(): number {
+    return this.lastPosition;
+  }
+
+  /**
+   * Get remaining time until fade starts
+   *
+   * @returns Remaining milliseconds, or 0 if inactive
+   */
+  getRemainingMs(): number {
+    if (this.phase === 'inactive') {
+      return 0;
+    }
+    return Math.max(0, this.endTime - Date.now());
+  }
+
+  /**
+   * Check if timer is active
+   */
+  isActive(): boolean {
+    return this.phase !== 'inactive';
+  }
+
+  /**
+   * Get full timer state
+   */
+  getState(): CastSleepTimerState {
+    return {
+      active: this.phase !== 'inactive',
+      phase: this.phase,
+      remainingMs: this.getRemainingMs(),
+      position: this.lastPosition,
+      totalDurationMs: this.options.durationMs,
+      fadeDurationMs: this.fadeDurationMs,
+    };
+  }
+
+  /**
+   * Poll Cast client for current position
+   */
+  private async pollPosition(): Promise<void> {
+    if (this.phase === 'inactive') {
+      return;
+    }
+
+    try {
+      // Check connection first
+      if (!this.castClient.isConnected()) {
+        throw new Error('Cast client not connected');
+      }
+
+      const status = await this.castClient.getStatus();
+
+      if (!status) {
+        return;
+      }
+
+      // Handle playback ending naturally
+      if (status.playerState === PlayerState.IDLE) {
+        this.handlePlaybackEnded();
+        return;
+      }
+
+      // Update position
+      this.lastPosition = status.currentTime;
+
+      // Sync position to callback
+      if (this.onPositionSync) {
+        await this.onPositionSync(this.lastPosition);
+      }
+    } catch (error) {
+      // Connection lost or other error
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.handleError(err);
+    }
+  }
+
+  /**
+   * Report progress to callback
+   */
+  private reportProgress(): void {
+    if (this.phase !== 'countdown') {
+      return;
+    }
+
+    const remaining = this.getRemainingMs();
+    this.onProgress?.(remaining);
+  }
+
+  /**
+   * Execute the stop sequence: fade → pause → sync
+   */
+  private async executeStop(): Promise<void> {
+    if (this.phase !== 'countdown') {
+      return;
+    }
+
+    this.phase = 'fading';
+
+    // Clear countdown interval (keep sync for final position)
+    if (this.countdownInterval) {
+      clearInterval(this.countdownInterval);
+      this.countdownInterval = undefined;
+    }
+
+    let fadeResult: FadeResult | null = null;
+    let fadeError: Error | null = null;
+
+    try {
+      // Fade volume via proxy (silent!)
+      fadeResult = await fadeOut(this.volumeTransform, this.fadeDurationMs, {
+        steps: this.fadeSteps,
+        signal: this.abortController?.signal,
+      });
+    } catch (error) {
+      fadeError = error instanceof Error ? error : new Error(String(error));
+      this.onError?.(fadeError, this.lastPosition);
+    }
+
+    // If cancelled during fade, don't continue
+    // Note: cancel() sets phase to 'inactive' via cleanup() during fade
+    if (fadeResult?.cancelled || this.abortController?.signal.aborted) {
+      this.cleanup();
+      return;
+    }
+
+    this.phase = 'completing';
+
+    // Get final position
+    try {
+      const status = await this.castClient.getStatus();
+      if (status?.currentTime !== undefined) {
+        this.lastPosition = status.currentTime;
+      }
+    } catch {
+      // Use last known position
+    }
+
+    // Sync final position
+    try {
+      if (this.onPositionSync) {
+        await this.onPositionSync(this.lastPosition);
+      }
+    } catch {
+      // Continue anyway
+    }
+
+    // Pause Cast playback
+    try {
+      await this.castClient.pause();
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.onError?.(err, this.lastPosition);
+    }
+
+    // Complete
+    const finalPosition = this.lastPosition;
+    this.cleanup();
+    this.onComplete?.(finalPosition);
+  }
+
+  /**
+   * Handle playback ending naturally (before timer)
+   */
+  private handlePlaybackEnded(): void {
+    // Playback finished on its own, cancel timer
+    this.cleanup();
+  }
+
+  /**
+   * Handle errors during timer operation
+   */
+  private handleError(error: Error): void {
+    this.onError?.(error, this.lastPosition);
+    this.cleanup();
+  }
+
+  /**
+   * Clean up all timers and state
+   */
+  private cleanup(): void {
+    this.phase = 'inactive';
+
+    if (this.countdownInterval) {
+      clearInterval(this.countdownInterval);
+      this.countdownInterval = undefined;
+    }
+
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = undefined;
+    }
+
+    if (this.countdownTimeout) {
+      clearTimeout(this.countdownTimeout);
+      this.countdownTimeout = undefined;
+    }
+
+    this.abortController = undefined;
+
+    // Resolve the start() promise
+    if (this.runPromiseResolve) {
+      this.runPromiseResolve();
+      this.runPromiseResolve = undefined;
+    }
+  }
+}

--- a/tests/cast-sleep-timer.test.ts
+++ b/tests/cast-sleep-timer.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Tests for Cast Sleep Timer with fade-out
+ *
+ * Tests the enhanced sleep timer that integrates with audio proxy
+ * for silent volume fades and position tracking.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the modules before importing
+vi.mock('../src/proxy/fade.js', () => ({
+  fadeOut: vi.fn().mockResolvedValue({
+    completed: true,
+    finalVolume: 0,
+    stepsExecuted: 30,
+    cancelled: false,
+  }),
+  FadeAbortedError: class extends Error {
+    constructor(
+      public readonly finalVolume: number,
+      public readonly stepsExecuted: number
+    ) {
+      super('Fade operation was aborted');
+      this.name = 'FadeAbortedError';
+    }
+  },
+}));
+
+import {
+  CastSleepTimer,
+  type CastSleepTimerOptions,
+  type CastSleepTimerState,
+} from '../src/cast/sleep-timer.js';
+import { fadeOut } from '../src/proxy/fade.js';
+
+// Mock CastClient
+function createMockCastClient() {
+  return {
+    pause: vi.fn().mockResolvedValue(undefined),
+    getStatus: vi.fn().mockResolvedValue({
+      currentTime: 100,
+      playerState: 'PLAYING',
+    }),
+    isConnected: vi.fn().mockReturnValue(true),
+    on: vi.fn(),
+    off: vi.fn(),
+    removeListener: vi.fn(),
+  };
+}
+
+// Mock VolumeTransform
+function createMockVolumeTransform() {
+  return {
+    volume: 1.0,
+    setVolume: vi.fn(),
+  };
+}
+
+describe('CastSleepTimer', () => {
+  let timer: CastSleepTimer | undefined;
+  let mockCastClient: ReturnType<typeof createMockCastClient>;
+  let mockVolumeTransform: ReturnType<typeof createMockVolumeTransform>;
+  let onProgress: ReturnType<typeof vi.fn>;
+  let onPositionSync: ReturnType<typeof vi.fn>;
+  let onComplete: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    mockCastClient = createMockCastClient();
+    mockVolumeTransform = createMockVolumeTransform();
+
+    onProgress = vi.fn();
+    onPositionSync = vi.fn().mockResolvedValue(undefined);
+    onComplete = vi.fn();
+    onError = vi.fn();
+  });
+
+  afterEach(() => {
+    timer?.cancel();
+    vi.useRealTimers();
+  });
+
+  function createTimer(overrides: Partial<CastSleepTimerOptions> = {}): CastSleepTimer {
+    const options: CastSleepTimerOptions = {
+      durationMs: 60000, // 1 minute
+      fadeDurationMs: 5000, // 5 second fade
+      fadeSteps: 10,
+      syncIntervalMs: 10000, // 10 second sync interval
+      latencyCompensationMs: 0, // Disable for predictable tests
+      onProgress,
+      onPositionSync,
+      onComplete,
+      onError,
+      ...overrides,
+    };
+
+    return new CastSleepTimer(
+      mockCastClient as unknown as ConstructorParameters<typeof CastSleepTimer>[0],
+      mockVolumeTransform as unknown as ConstructorParameters<typeof CastSleepTimer>[1],
+      options
+    );
+  }
+
+  describe('constructor', () => {
+    it('should accept required options', () => {
+      timer = createTimer();
+      expect(timer).toBeDefined();
+    });
+
+    it('should use default values for optional options', () => {
+      timer = new CastSleepTimer(
+        mockCastClient as unknown as ConstructorParameters<typeof CastSleepTimer>[0],
+        mockVolumeTransform as unknown as ConstructorParameters<typeof CastSleepTimer>[1],
+        { durationMs: 30000 }
+      );
+      expect(timer).toBeDefined();
+    });
+  });
+
+  describe('start', () => {
+    it('should start the timer and track state', async () => {
+      timer = createTimer();
+      // Don't await start() directly - just check state
+      void timer.start();
+
+      // Give time for initial poll
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(timer.isActive()).toBe(true);
+      expect(timer.getRemainingMs()).toBeLessThanOrEqual(60000);
+
+      timer.cancel();
+    });
+
+    it('should throw if already running', async () => {
+      timer = createTimer();
+      const promise1 = timer.start();
+
+      await expect(timer.start()).rejects.toThrow(/already running/i);
+
+      timer.cancel();
+      await promise1;
+    });
+
+    it('should call onProgress during countdown', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      // Advance time partially
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(onProgress).toHaveBeenCalled();
+      const calls = onProgress.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+
+      timer.cancel();
+      await promise;
+    });
+
+    it('should sync position periodically', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      // Advance past one sync interval (10 seconds)
+      await vi.advanceTimersByTimeAsync(11000);
+
+      expect(onPositionSync).toHaveBeenCalled();
+
+      timer.cancel();
+      await promise;
+    });
+
+    it('should get position from Cast client', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(11000);
+
+      expect(mockCastClient.getStatus).toHaveBeenCalled();
+
+      timer.cancel();
+      await promise;
+    });
+  });
+
+  describe('fade-out and complete', () => {
+    it('should fade volume before pausing', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      // Advance to end of countdown (triggers fade)
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(fadeOut).toHaveBeenCalledWith(
+        mockVolumeTransform,
+        5000, // fadeDurationMs
+        expect.objectContaining({ steps: 10 })
+      );
+
+      await promise;
+    });
+
+    it('should pause Cast after fade completes', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(mockCastClient.pause).toHaveBeenCalled();
+      await promise;
+    });
+
+    it('should call onComplete with final position', async () => {
+      mockCastClient.getStatus.mockResolvedValue({
+        currentTime: 150,
+        playerState: 'PLAYING',
+      });
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(onComplete).toHaveBeenCalledWith(150);
+      await promise;
+    });
+
+    it('should sync final position before completing', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      // onPositionSync should be called with the final position
+      expect(onPositionSync).toHaveBeenCalled();
+      await promise;
+    });
+  });
+
+  describe('cancel', () => {
+    it('should cancel active timer', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(30000); // Half way
+      const position = timer.cancel();
+
+      expect(timer.isActive()).toBe(false);
+      expect(position).toBeGreaterThanOrEqual(0);
+
+      await promise;
+    });
+
+    it('should return last known position', async () => {
+      mockCastClient.getStatus.mockResolvedValue({
+        currentTime: 75,
+        playerState: 'PLAYING',
+      });
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      // Advance and let position sync
+      await vi.advanceTimersByTimeAsync(11000);
+
+      const position = timer.cancel();
+      expect(position).toBe(75);
+
+      await promise;
+    });
+
+    it('should not call onComplete when cancelled', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(30000);
+      timer.cancel();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(onComplete).not.toHaveBeenCalled();
+      await promise;
+    });
+  });
+
+  describe('getPosition', () => {
+    it('should return current tracked position', async () => {
+      mockCastClient.getStatus.mockResolvedValue({
+        currentTime: 42,
+        playerState: 'PLAYING',
+      });
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(11000);
+
+      expect(timer.getPosition()).toBe(42);
+
+      timer.cancel();
+      await promise;
+    });
+
+    it('should return 0 if not started', () => {
+      timer = createTimer();
+      expect(timer.getPosition()).toBe(0);
+    });
+  });
+
+  describe('getRemainingMs', () => {
+    it('should return remaining time', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(20000);
+
+      const remaining = timer.getRemainingMs();
+      expect(remaining).toBeLessThanOrEqual(40000);
+      expect(remaining).toBeGreaterThan(0);
+
+      timer.cancel();
+      await promise;
+    });
+
+    it('should return 0 if not active', () => {
+      timer = createTimer();
+      expect(timer.getRemainingMs()).toBe(0);
+    });
+  });
+
+  describe('getState', () => {
+    it('should return full timer state', async () => {
+      mockCastClient.getStatus.mockResolvedValue({
+        currentTime: 100,
+        playerState: 'PLAYING',
+      });
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(11000);
+
+      const state = timer.getState();
+
+      expect(state).toMatchObject<Partial<CastSleepTimerState>>({
+        active: true,
+        position: 100,
+        phase: 'countdown',
+      });
+      expect(state.remainingMs).toBeLessThan(60000);
+
+      timer.cancel();
+      await promise;
+    });
+
+    it('should report "inactive" when not running', () => {
+      timer = createTimer();
+      const state = timer.getState();
+      expect(state.active).toBe(false);
+      expect(state.phase).toBe('inactive');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle playback ending naturally during countdown', async () => {
+      // After some time, status shows IDLE (finished)
+      mockCastClient.getStatus
+        .mockResolvedValueOnce({ currentTime: 50, playerState: 'PLAYING' })
+        .mockResolvedValueOnce({ currentTime: 100, playerState: 'IDLE' });
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      // First poll
+      await vi.advanceTimersByTimeAsync(11000);
+
+      // Second poll - playback ended
+      await vi.advanceTimersByTimeAsync(11000);
+
+      // Timer should have deactivated
+      expect(timer.isActive()).toBe(false);
+
+      await promise;
+    });
+
+    it('should handle connection loss gracefully', async () => {
+      mockCastClient.isConnected.mockReturnValue(false);
+      mockCastClient.getStatus.mockRejectedValue(new Error('Not connected'));
+
+      timer = createTimer();
+      void timer.start();
+
+      // Give time for initial poll (which will fail)
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(onError).toHaveBeenCalled();
+      expect(timer.isActive()).toBe(false);
+    });
+
+    it('should handle fade failure gracefully', async () => {
+      vi.mocked(fadeOut).mockRejectedValue(new Error('Fade failed'));
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      // Should still try to pause
+      expect(mockCastClient.pause).toHaveBeenCalled();
+      expect(onError).toHaveBeenCalled();
+
+      await promise;
+    });
+
+    it('should handle pause failure gracefully', async () => {
+      mockCastClient.pause.mockRejectedValue(new Error('Pause failed'));
+
+      timer = createTimer();
+      const promise = timer.start();
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(onError).toHaveBeenCalled();
+      expect(timer.isActive()).toBe(false);
+
+      await promise;
+    });
+
+    it('should sync position multiple times during countdown', async () => {
+      timer = createTimer();
+      const promise = timer.start();
+
+      // Multiple sync intervals (25 seconds = 2+ intervals of 10s each)
+      await vi.advanceTimersByTimeAsync(25000);
+
+      expect(onPositionSync.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      timer.cancel();
+      await promise;
+    });
+  });
+
+  describe('latency compensation', () => {
+    it('should start fade early when latency compensation is set', async () => {
+      timer = createTimer({ latencyCompensationMs: 2000 });
+      const promise = timer.start();
+
+      // At 58 seconds (60 - 2 latency), fade should trigger
+      await vi.advanceTimersByTimeAsync(58000);
+
+      // Fade should have been called
+      expect(fadeOut).toHaveBeenCalled();
+
+      await promise;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements a skill-managed sleep timer with countdown, silent volume fade-out via audio proxy, and position preservation.

## Changes
- **New file**: `src/cast/sleep-timer.ts` with `CastSleepTimer` class
- **Tests**: `tests/cast-sleep-timer.test.ts` (26 tests)
- **Exports**: Updated `src/cast/index.ts`

## Features
- Timer countdown with configurable duration
- Silent volume fade via PCM stream (no Cast bloops)
- Position tracking during countdown with periodic sync
- Latency compensation for audio buffer delay
- Callbacks for progress, position sync, completion, errors
- Graceful handling of edge cases:
  - Natural playback end
  - Connection loss
  - Fade/pause failures
  - Cancellation during any phase

## Architecture
```
Timer countdown → Poll position → Fade volume (via proxy) → Pause Cast → Sync final position
```

## Testing
- All 255 tests pass
- Typecheck passes
- Lint passes

Closes #22