### PR TITLE
[#23] CLI command updates

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -24,6 +24,7 @@ export interface CLIArgs {
   device?: string;
   name?: string;
   minutes?: number;
+  fade?: number;
   [key: string]: string | number | undefined;
 }
 
@@ -64,6 +65,7 @@ const COMMANDS = [
   'devices',
   'device',
   'sleep',
+  'status',
   'help',
   'version',
 ];
@@ -132,6 +134,18 @@ export function parseCLI(argv: string[]): CLIResult {
       i++;
       if (i < argv.length) {
         result.args.device = argv[i];
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === '--fade' || arg === '-f') {
+      i++;
+      if (i < argv.length) {
+        const fadeSeconds = parseInt(argv[i], 10);
+        if (!isNaN(fadeSeconds)) {
+          result.args.fade = fadeSeconds;
+        }
       }
       i++;
       continue;
@@ -228,8 +242,14 @@ export function parseCLI(argv: string[]): CLIResult {
           result.exitCode = 2;
         } else {
           result.args.minutes = minutes;
+          // Set default fade duration if not specified
+          result.args.fade = result.args.fade ?? 30;
         }
       }
+      break;
+
+    case 'status':
+      // Status command takes no required arguments
       break;
   }
 
@@ -250,15 +270,18 @@ Commands:
   resume [--device <name>]    Resume last book
   pause                       Pause current playback
   stop                        Stop and sync progress
-  devices                     List Cast devices
+  status                      Show current playback status
+  devices                     List Cast devices (with IDs)
   device set "<name>"         Set default device
-  sleep <minutes>             Set sleep timer
+  sleep <min> [--fade <sec>]  Set sleep timer (fade default: 30s)
   sleep cancel                Cancel sleep timer
   sleep status                Show timer status
 
 Options:
   -h, --help                  Show this help
   -v, --version               Show version
+  -d, --device <name>         Target Cast device
+  -f, --fade <seconds>        Fade duration for sleep timer
   --json                      Output as JSON
 
 Environment Variables:

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -218,6 +218,42 @@ describe('CLI Parser', () => {
       expect(result.error).toBeDefined();
       expect(result.exitCode).toBe(2);
     });
+
+    it('should parse "sleep <minutes> --fade <seconds>"', () => {
+      const result = parseCLI(['sleep', '30', '--fade', '45']);
+      expect(result.command).toBe('sleep');
+      expect(result.args.minutes).toBe(30);
+      expect(result.args.fade).toBe(45);
+    });
+
+    it('should parse "sleep <minutes> -f <seconds>"', () => {
+      const result = parseCLI(['sleep', '30', '-f', '60']);
+      expect(result.command).toBe('sleep');
+      expect(result.args.minutes).toBe(30);
+      expect(result.args.fade).toBe(60);
+    });
+
+    it('should use default fade of 30 seconds when not specified', () => {
+      const result = parseCLI(['sleep', '30']);
+      expect(result.args.fade).toBe(30);
+    });
+  });
+
+  describe('status command', () => {
+    it('should parse "status"', () => {
+      const result = parseCLI(['status']);
+      expect(result.command).toBe('status');
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should parse "status --json"', () => {
+      const result = parseCLI(['status', '--json']);
+      expect(result.command).toBe('status');
+      expect(result.flags.json).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe('unknown command', () => {


### PR DESCRIPTION
## Summary
Updates CLI commands for native Cast support per Issue #23.

## Changes

### CLI Parser (src/lib/cli.ts)
- Added `status` command to COMMANDS list
- Added `--fade` / `-f` flag for sleep timer with configurable fade duration
- Default fade duration: 30 seconds
- Updated help text with new commands and options

### CLI Implementation (src/bin/abs.ts)
- Added `status` command handler (placeholder for full session persistence)
- Updated `devices` command to show device IDs from mDNS TXT record
- Updated `sleep` command to display and use fade duration

### Tests
- Added 5 new CLI tests:
  - `sleep <minutes> --fade <seconds>`
  - `sleep <minutes> -f <seconds>`
  - Default fade of 30 seconds
  - `status` command
  - `status --json` command

## Testing
- All 260 tests pass
- Typecheck passes
- Lint passes

Closes #23