### PR TITLE
[#26] Service packaging and deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Audiobookshelf Cast Proxy - Environment Configuration
+#
+# Copy this file to .env and edit with your settings:
+#   cp .env.example .env
+
+# Audiobookshelf server URL (required)
+ABS_SERVER=https://your-audiobookshelf-server.com
+
+# Audiobookshelf API token (required)
+# Get from: Settings → Users → Your User → API Token
+ABS_TOKEN=your-api-token
+
+# Default Cast device name (optional)
+ABS_DEVICE=Living Room Speaker
+
+# Proxy server port (default: 8765)
+ABS_PROXY_PORT=8765
+
+# Request timeout in milliseconds (default: 10000)
+ABS_TIMEOUT=10000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Environment variable configuration
   - Device discovery and connection tests
 
+- **Service packaging** — Deployment configurations (#26)
+  - `abs service run/start/stop/status` CLI commands
+  - systemd unit file for Linux
+  - launchd plist for macOS
+  - Dockerfile and docker-compose.yml
+  - Health check endpoint (`/health`)
+
 ### Changed
 
 - Sleep timer now defaults to 30-second fade

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Audiobookshelf Cast Proxy - Docker Image
+#
+# Build:
+#   docker build -t abs-proxy .
+#
+# Run:
+#   docker run -d \
+#     -e ABS_SERVER=https://your-audiobookshelf-server.com \
+#     -e ABS_TOKEN=your-api-token \
+#     -p 8765:8765 \
+#     abs-proxy
+#
+# With volume for config:
+#   docker run -d \
+#     -v /path/to/config:/config \
+#     -p 8765:8765 \
+#     abs-proxy
+
+FROM node:22-alpine
+
+# Install ffmpeg for audio processing
+RUN apk add --no-cache ffmpeg
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm and dependencies
+RUN npm install -g pnpm && \
+    pnpm install --prod --frozen-lockfile
+
+# Copy built application
+COPY dist ./dist
+COPY SKILL.md README.md LICENSE ./
+
+# Create non-root user
+RUN addgroup -g 1001 -S absgroup && \
+    adduser -u 1001 -S absuser -G absgroup
+
+USER absuser
+
+# Environment variables (override at runtime)
+ENV NODE_ENV=production
+ENV ABS_PROXY_PORT=8765
+# ABS_SERVER and ABS_TOKEN must be provided at runtime
+
+# Expose proxy port
+EXPOSE 8765
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:${ABS_PROXY_PORT}/health || exit 1
+
+# Run proxy server
+CMD ["node", "dist/bin/abs.js", "service", "run"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,116 @@
+# Deployment Files
+
+This directory contains deployment configurations for running the audio proxy as a service.
+
+## Quick Start
+
+### Integrated Mode (CLI)
+
+Run the proxy directly:
+
+```bash
+# Run in foreground (Ctrl+C to stop)
+abs service run
+
+# Check if proxy is running
+abs service status
+```
+
+### Docker
+
+The easiest way to run the proxy as a persistent service:
+
+```bash
+# Build the image
+docker build -t abs-proxy .
+
+# Run with environment variables
+docker run -d \
+  --name abs-proxy \
+  -e ABS_SERVER=https://your-server.com \
+  -e ABS_TOKEN=your-token \
+  -p 8765:8765 \
+  abs-proxy
+
+# Or use docker-compose
+cp .env.example .env
+# Edit .env with your settings
+docker-compose up -d
+```
+
+### systemd (Linux)
+
+For Linux servers:
+
+```bash
+# Copy the service file
+sudo cp deploy/abs-proxy.service /etc/systemd/system/
+
+# Edit the environment variables
+sudo systemctl edit abs-proxy
+# Or create /etc/abs-proxy.env with ABS_SERVER and ABS_TOKEN
+
+# Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable abs-proxy
+sudo systemctl start abs-proxy
+
+# Check status
+sudo systemctl status abs-proxy
+journalctl -u abs-proxy -f
+```
+
+### launchd (macOS)
+
+For macOS:
+
+```bash
+# Copy the plist file
+cp deploy/com.openclaw.abs-proxy.plist ~/Library/LaunchAgents/
+
+# Edit the EnvironmentVariables in the plist file
+nano ~/Library/LaunchAgents/com.openclaw.abs-proxy.plist
+
+# Load the service
+launchctl load ~/Library/LaunchAgents/com.openclaw.abs-proxy.plist
+
+# Check status
+launchctl list | grep abs-proxy
+
+# View logs
+tail -f /tmp/abs-proxy.log
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ABS_SERVER` | Audiobookshelf server URL | Required |
+| `ABS_TOKEN` | API token | Required |
+| `ABS_PROXY_PORT` | Proxy listen port | 8765 |
+
+### Health Check
+
+The proxy exposes a health endpoint:
+
+```bash
+curl http://localhost:8765/health
+# {"status":"ok","sessions":0}
+```
+
+## Network Requirements
+
+For Cast device discovery (mDNS), the proxy needs to be on the same network as your Cast devices.
+
+- **Docker bridge mode**: Cast discovery won't work. Use `--network host` or a macvlan network.
+- **Docker host mode**: Full Cast discovery works, but port conflicts are possible.
+- **Systemd/launchd**: Full Cast discovery works.
+
+## Files
+
+- `abs-proxy.service` - systemd unit file for Linux
+- `com.openclaw.abs-proxy.plist` - launchd plist for macOS
+- `../Dockerfile` - Docker image definition
+- `../docker-compose.yml` - Docker Compose configuration

--- a/deploy/abs-proxy.service
+++ b/deploy/abs-proxy.service
@@ -1,0 +1,49 @@
+# Audiobookshelf Cast Proxy - systemd unit file
+#
+# Installation:
+#   1. Copy this file to /etc/systemd/system/abs-proxy.service
+#   2. Edit Environment variables or create /etc/abs-proxy.env
+#   3. sudo systemctl daemon-reload
+#   4. sudo systemctl enable abs-proxy
+#   5. sudo systemctl start abs-proxy
+#
+# Or use: abs service start (if running as root/sudo)
+
+[Unit]
+Description=Audiobookshelf Cast Proxy
+Documentation=https://github.com/troykelly/openclaw-skill-audiobookshelf
+After=network.target
+
+[Service]
+Type=simple
+User=nobody
+Group=nogroup
+
+# Set these to your Audiobookshelf server details
+# Option 1: Direct environment variables
+Environment=ABS_SERVER=https://your-audiobookshelf-server.com
+Environment=ABS_TOKEN=your-api-token
+Environment=ABS_PROXY_PORT=8765
+
+# Option 2: Environment file (uncomment and create file)
+#EnvironmentFile=/etc/abs-proxy.env
+
+# Run the proxy server
+ExecStart=/usr/bin/abs service run
+
+# Restart on failure
+Restart=on-failure
+RestartSec=5
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+
+# Allow binding to network ports
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/com.openclaw.abs-proxy.plist
+++ b/deploy/com.openclaw.abs-proxy.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Audiobookshelf Cast Proxy - launchd plist for macOS
+
+  Installation:
+    1. Copy this file to ~/Library/LaunchAgents/com.openclaw.abs-proxy.plist
+    2. Edit the EnvironmentVariables section with your server details
+    3. launchctl load ~/Library/LaunchAgents/com.openclaw.abs-proxy.plist
+
+  Or for system-wide installation:
+    1. Copy to /Library/LaunchDaemons/com.openclaw.abs-proxy.plist
+    2. sudo launchctl load /Library/LaunchDaemons/com.openclaw.abs-proxy.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.openclaw.abs-proxy</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/abs</string>
+        <string>service</string>
+        <string>run</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ABS_SERVER</key>
+        <string>https://your-audiobookshelf-server.com</string>
+        <key>ABS_TOKEN</key>
+        <string>your-api-token</string>
+        <key>ABS_PROXY_PORT</key>
+        <string>8765</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/abs-proxy.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/abs-proxy.err</string>
+
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# Audiobookshelf Cast Proxy - Docker Compose
+#
+# Usage:
+#   1. Copy .env.example to .env and configure
+#   2. docker-compose up -d
+#
+# Or with environment variables:
+#   ABS_SERVER=... ABS_TOKEN=... docker-compose up -d
+
+version: '3.8'
+
+services:
+  abs-proxy:
+    build: .
+    image: abs-proxy:latest
+    container_name: abs-proxy
+    restart: unless-stopped
+    ports:
+      - "${ABS_PROXY_PORT:-8765}:8765"
+    environment:
+      - ABS_SERVER=${ABS_SERVER}
+      - ABS_TOKEN=${ABS_TOKEN}
+      - ABS_PROXY_PORT=8765
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8765/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    # For mDNS device discovery, use host network
+    # network_mode: host

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -66,9 +66,12 @@ const COMMANDS = [
   'device',
   'sleep',
   'status',
+  'service',
   'help',
   'version',
 ];
+
+const SERVICE_SUBCOMMANDS = ['run', 'start', 'stop', 'status'];
 
 /**
  * Parse CLI arguments
@@ -251,6 +254,18 @@ export function parseCLI(argv: string[]): CLIResult {
     case 'status':
       // Status command takes no required arguments
       break;
+
+    case 'service':
+      if (positional.length < 2) {
+        result.error = 'service requires a subcommand (run, start, stop, status)';
+        result.exitCode = 2;
+      } else if (SERVICE_SUBCOMMANDS.includes(positional[1])) {
+        result.subcommand = positional[1];
+      } else {
+        result.error = `Unknown service subcommand: ${positional[1]}`;
+        result.exitCode = 2;
+      }
+      break;
   }
 
   return result;
@@ -276,6 +291,10 @@ Commands:
   sleep <min> [--fade <sec>]  Set sleep timer (fade default: 30s)
   sleep cancel                Cancel sleep timer
   sleep status                Show timer status
+  service run                 Run proxy server (foreground)
+  service start               Start proxy daemon
+  service stop                Stop proxy daemon
+  service status              Show proxy status
 
 Options:
   -h, --help                  Show this help
@@ -288,6 +307,7 @@ Environment Variables:
   ABS_SERVER                  Audiobookshelf server URL
   ABS_TOKEN                   API token
   ABS_DEVICE                  Default Cast device name
+  ABS_PROXY_PORT              Proxy server port (default: 8765)
 
 Exit Codes:
   0  Success

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -256,6 +256,45 @@ describe('CLI Parser', () => {
     });
   });
 
+  describe('service command', () => {
+    it('should parse "service run"', () => {
+      const result = parseCLI(['service', 'run']);
+      expect(result.command).toBe('service');
+      expect(result.subcommand).toBe('run');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should parse "service start"', () => {
+      const result = parseCLI(['service', 'start']);
+      expect(result.command).toBe('service');
+      expect(result.subcommand).toBe('start');
+    });
+
+    it('should parse "service stop"', () => {
+      const result = parseCLI(['service', 'stop']);
+      expect(result.command).toBe('service');
+      expect(result.subcommand).toBe('stop');
+    });
+
+    it('should parse "service status"', () => {
+      const result = parseCLI(['service', 'status']);
+      expect(result.command).toBe('service');
+      expect(result.subcommand).toBe('status');
+    });
+
+    it('should error on "service" without subcommand', () => {
+      const result = parseCLI(['service']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('should error on "service invalid"', () => {
+      const result = parseCLI(['service', 'invalid']);
+      expect(result.error).toBeDefined();
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
   describe('unknown command', () => {
     it('should error on unknown command', () => {
       const result = parseCLI(['foobar']);


### PR DESCRIPTION
## Summary
Adds service packaging and deployment configurations per Issue #26.

## Changes

### CLI Commands
- `abs service run` — Run proxy server in foreground
- `abs service start` — Start proxy daemon (guidance only)
- `abs service stop` — Stop proxy daemon (guidance only)
- `abs service status` — Check if proxy is running via health endpoint

### Deployment Files
- `Dockerfile` — Docker image with Node.js and ffmpeg
- `docker-compose.yml` — Docker Compose configuration
- `deploy/abs-proxy.service` — systemd unit file for Linux
- `deploy/com.openclaw.abs-proxy.plist` — launchd plist for macOS
- `deploy/README.md` — Deployment instructions
- `.env.example` — Configuration template

### Features
- Health check endpoint (`/health`) for container orchestration
- Environment variable configuration
- Signal handling (SIGINT/SIGTERM) for graceful shutdown
- Non-root user in Docker container

## Deployment Modes

1. **Integrated**: CLI starts proxy on-demand
2. **Standalone Service**: systemd/launchd managed
3. **Docker**: Container with health checks

## Testing
- All 266 unit tests pass
- 9 integration tests skipped (require real device)
- 6 new CLI tests for service command
- Typecheck passes
- Lint passes

Closes #26